### PR TITLE
Update ietf-tpm-remote-attestation.yang

### DIFF
--- a/ietf-tpm-remote-attestation.yang
+++ b/ietf-tpm-remote-attestation.yang
@@ -8,14 +8,11 @@ module ietf-tpm-remote-attestation {
   import ietf-hardware {
     prefix ietfhw;
   }
-  import ietf-crypto-types {
-    prefix ct;
-  }
   import ietf-keystore {
     prefix ks;
   }
-  import ietf-asymmetric-algs {
-    prefix aa;
+  import ietf-tcg-algs {
+    prefix taa;
   }
 
   organization
@@ -24,11 +21,11 @@ module ietf-tpm-remote-attestation {
   contact
    "WG Web  : <http://datatracker.ietf.org/wg/rats/>
     WG List : <mailto:rats@ietf.org>
+    Author  : Eric Voit <evoit@cisco.com>
     Author  : Henk Birkholz <henk.birkholz@sit.fraunhofer.de>
     Author  : Michael Eckel <michael.eckel@sit.fraunhofer.de>
     Author  : Shwetha Bhandari <shwethab@cisco.com>
     Author  : Bill Sulzen <bsulzen@cisco.com>
-    Author  : Eric Voit <evoit@cisco.com>
     Author  : Liang Xia (Frank) <frank.xialiang@huawei.com>
     Author  : Tom Laffey <tom.laffey@hpe.com>
     Author  : Guy Fedorkow <gfedorkow@juniper.net>";
@@ -39,14 +36,14 @@ module ietf-tpm-remote-attestation {
      interaction model and the TPM 1.2 and TPM 2.0 Quote
      primitive operations.
 
-     Copyright (c) 2020 IETF Trust and the persons identified as
-     authors of the code.  All rights reserved.
+     Copyright (c) 2020 IETF Trust and the persons identified
+     as authors of the code. All rights reserved.
 
-     Redistribution and use in source and binary forms, with or
-     without modification, is permitted pursuant to, and subject to
-     the license terms contained in, the Simplified BSD License set
-     forth in Section 4.c of the IETF Trust's Legal Provisions
-     Relating to IETF Documents
+     Redistribution and use in source and binary forms, with
+     or without modification, is permitted pursuant to, and
+     subject to the license terms contained in, the Simplified
+     BSD License set forth in Section 4.c of the IETF Trust's
+     Legal Provisions Relating to IETF Documents
      (https://trustee.ietf.org/license-info).
      
      Redistribution and use in source and binary forms, with or
@@ -57,37 +54,23 @@ module ietf-tpm-remote-attestation {
      (https://trustee.ietf.org/license-info).
 
      This version of this YANG module is part of RFC XXXX
-     (https://www.rfc-editor.org/info/rfcXXXX); see the RFC itself
-     for full legal notices.
+     (https://www.rfc-editor.org/info/rfcXXXX); see the RFC
+     itself for full legal notices.
 
-     The key words 'MUST', 'MUST NOT', 'REQUIRED', 'SHALL', 'SHALL
-     NOT', 'SHOULD', 'SHOULD NOT', 'RECOMMENDED', 'NOT RECOMMENDED',
-     'MAY', and 'OPTIONAL' in this document are to be interpreted as
-     described in BCP 14 (RFC 2119) (RFC 8174) when, and only when,
-     they appear in all capitals, as shown here.";
+     The key words 'MUST', 'MUST NOT', 'REQUIRED', 'SHALL',
+     'SHALL NOT', 'SHOULD', 'SHOULD NOT', 'RECOMMENDED',
+     'NOT RECOMMENDED', 'MAY', and 'OPTIONAL' in this document
+     are to be interpreted as described in BCP 14 (RFC 2119)
+     (RFC 8174) when, and only when, they appear in all
+     capitals, as shown here.";
 
-  revision "2020-06-23" {
+  revision "2020-08-27" {
     description
       "Initial version";
     reference
       "draft-ietf-rats-yang-tpm-charra";
   }
 
-  /*****************/
-  /*   Features    */
-  /*****************/
-
-  feature TPM12 {
-    description
-      "This feature indicates that an Attester includes cryptoprocessors
-       capable of supporting the TPM 1.2 API.";
-  }
-
-  feature TPM20 {
-    description
-      "This feature indicates that an Attester includes cryptoprocessors
-       capable of supporting the TPM 2 API.";
-  }
 
   /*****************/
   /*   Typedefs    */
@@ -103,11 +86,22 @@ module ietf-tpm-remote-attestation {
 
   typedef compute-node-ref {
     type leafref {
-      path "/tpm:rats-support-structures/tpm:compute-nodes/tpm:node-name";
+      path "/tpm:rats-support-structures/tpm:compute-nodes" +
+           "/tpm:compute-node/tpm:node-name";
     }
     description
-      "This type is used to reference a hardware node.  It is quite possible
-       this leafref will eventually point to another YANG module's node.";
+      "This type is used to reference a hardware node.  It is quite 
+      possible this leafref will eventually point to another YANG 
+      module's node.";
+  }
+
+  typedef certificate-name-ref {
+    type leafref {
+      path "/tpm:rats-support-structures/tpm:tpms/tpm:tpm" +
+           "/tpm:certificates/tpm:certificate/tpm:certificate-name";
+    }
+    description
+      "A type which allows identification of a TPM based certificate.";
   }
 
 
@@ -118,7 +112,7 @@ module ietf-tpm-remote-attestation {
   identity attested-event-log-type {
     description
       "Base identity allowing categorization of the reasons why and
-       attested measurement has been taken on an Attester.";
+      attested measurement has been taken on an Attester.";
   }
 
   identity ima {
@@ -155,37 +149,81 @@ module ietf-tpm-remote-attestation {
   /*   Groupings   */
   /*****************/
   
-  grouping TPM2_Algo {
-    description
-      "The signature scheme that is used to sign the TPM2 Quote 
-       information response.";
-    leaf TPM2_Algo {
-      type identityref {
-        base aa:tpm2-asymmetric-algorithm;
-      }
-      description
-        "The signature scheme that is used to sign the TPM
-         Quote information response.";    
-    }
-  }
-
-  grouping TPM12_Algo {
+  grouping TPM20-asymmetric-signing-algo {
     description
       "The signature scheme that is used to sign the TPM2 Quote 
       information response.";
-    leaf TPM12_Algo {
+    leaf TPM20-asymmetric-signing-algo {
+      must "/tpm:rats-support-structures/tpm:attester-supported-algos"
+         + "/tpm:tpm20-asymmetric-signing";
       type identityref {
-        base aa:tpm12-asymmetric-algorithm;
+        base taa:asymmetric;
+      }
+      description
+        "The signature scheme that is used to sign the TPM2.0
+         Quote information response. This must be one of those 
+         supported by a platform.";   
+    default taa:TPM_ALG_RSA; 
+    }
+  }
+
+  grouping TPM12-asymmetric-signing-algo {
+    description
+      "The signature scheme that is used to sign the TPM2 Quote 
+      information response.";
+    leaf TPM12-asymmetric-signing-algo {
+      must "/tpm:rats-support-structures/tpm:attester-supported-algos"
+         + "/tpm:tpm12-asymmetric-signing";
+      type identityref {
+        base taa:asymmetric;
       }
       description
         "The signature scheme that is used to sign the TPM1.2
-         Quote information response.";    
+         Quote information response. This must be one of those 
+         supported by a platform.";   
+    default taa:TPM_ALG_RSA;          
     }
   }  
 
+  grouping TPM20-hash-algo {
+    description
+      "The cryptographic algorithm used to hash the TPM2 PCRs.  This
+      must be from the list of platform supported options.";
+    leaf TPM20-hash-algo {
+      must "/tpm:rats-support-structures/tpm:attester-supported-algos"
+         + "/tpm:tpm20-hash";
+      type identityref {
+        base taa:hash;
+      }
+      description
+        "The hash scheme that is used to hash a TPM1.2 PCR. This 
+        must be one of those supported by a platform.";            
+    default taa:TPM_ALG_SHA256; 
+    }
+  }
+
+  grouping TPM12-hash-algo {
+    description
+      "The cryptographic algorithm used to hash the TPM1.2 PCRs.";
+    leaf TPM12-hash-algo {
+      must "/tpm:rats-support-structures/tpm:attester-supported-algos"
+         + "/tpm:tpm12-hash";
+      type identityref {
+        base taa:hash;
+      }
+      description
+        "The hash scheme that is used to hash a TPM1.2 PCR. This 
+        must be one of those supported by a platform.  This assumes
+        that an algorithm other than SHA1 can be supported on some
+        TPM1.2 cryptoprocessor variant."; 
+      default taa:TPM_ALG_SHA1;         
+    }
+  } 
+
   grouping nonce {
     description
-      "A nonce to show freshness and counter replays.";
+      "A nonce to show freshness and to allow the detection
+      of replay attacks.";
     leaf nonce-value {
       type binary;
       mandatory true;
@@ -211,7 +249,7 @@ module ietf-tpm-remote-attestation {
       type pcr;
       description
         "The numbers/indexes of the PCRs. At the moment this is limited
-         to 32.";
+        to 32.";
     }
   }
 
@@ -219,123 +257,33 @@ module ietf-tpm-remote-attestation {
     description
       "A Verifier can acquire one or more PCR values, which are hashed 
        together in a TPM2B_DIGEST coming from the TPM2.  The selection 
-       list of desired PCRs and the Hash Algorithm is represented in this 
-       grouping.";
-    list pcr-list {
-      key "TPM2_Algo";
+       list of desired PCRs and the Hash Algorithm is represented in  
+       this grouping.";
+    list tpm20-pcr-selection {
+      unique "TPM20-hash-algo";
       description
-        "Specifies the list of PCRs and Hash Algorithms used for the   
-         latest returned TPM2B_DIGEST.";
+        "Specifies the list of PCRs and Hash Algorithms that can be   
+        returned within a TPM2B_DIGEST.";
       reference
         "https://www.trustedcomputinggroup.org/wp-content/uploads/
          TPM-Rev-2.0-Part-2-Structures-01.38.pdf  Section 10.9.7";
-      uses tpm:TPM2_Algo;
+      uses TPM20-hash-algo;
       leaf-list pcr-index {
         type tpm:pcr;
         description
-          "The numbers of the PCRs that are associated with 
-           the created key.";
-      }
-    }
-  }
-
-  grouping tpm12-attestation-key-identifier {
-    description
-      "A selector for a suitable key identifier for a TPM 1.2.";
-    choice key-identifier {
-      description
-        "Identifier for the attestation key to use for signing
-         attestation evidence.";
-      case public-key {
-        leaf pub-key-id {
-          type binary;
-          description
-            "The value of the identifier for the public key.";
-        }
-      }
-      case TSS_UUID {
-        description
-          "Use a YANG agent generated (and maintained) attestation
-           key UUID that complies with the TSS_UUID datatype of the TCG
-           Software Stack (TSS) Specification, Version 1.10 Golden,
-           August 20, 2003.";
-        container TSS_UUID-value {
-          description
-            "A detailed structure that is used to create the
-             TPM 1.2 native TSS_UUID as defined in the TCG Software
-             Stack (TSS) Specification, Version 1.10 Golden,
-             August 20, 2003.";
-          leaf ulTimeLow {
-            type uint32;
-            description
-              "The low field of the timestamp.";
-          }
-          leaf usTimeMid {
-            type uint16;
-            description
-              "The middle field of the timestamp.";
-          }
-          leaf usTimeHigh {
-            type uint16;
-            description
-              "The high field of the timestamp multiplexed with the
-               version number.";
-          }
-          leaf bClockSeqHigh {
-            type uint8;
-            description
-              "The high field of the clock sequence multiplexed with
-               the variant.";
-          }
-          leaf bClockSeqLow {
-            type uint8;
-            description
-              "The low field of the clock sequence.";
-          }
-          leaf-list rgbNode {
-            type uint8;
-            description
-              "The spatially unique node identifier.";
-          }
-        }
-      }
-    }
-  }
-
-  grouping tpm20-attestation-key-identifier {
-    description
-      "A selector for a suitable key identifier.";
-    choice key-identifier {
-      description
-        "Identifier for the attestation key to use for signing
-         attestation evidence.";
-      case public-key {
-        leaf pub-key-id {
-          type binary;
-          description
-            "The value of the identifier for the public key.";
-        }
-      }
-      case uuid {
-        description
-          "Use a YANG agent generated (and maintained) attestation
-           key UUID.";
-        leaf uuid-value {
-          type binary;
-          description
-            "The UUID identifying the corresponding public key.";
-        }
+          "The numbers of the PCRs that which are being tracked
+          with a hash based on the TPM20-hash-algo.";
       }
     }
   }
   
-  grouping certificate-name {
+  grouping certificate-name-ref {
     description
-      "An arbitrary name for the identity certificate chain requested.";
+      "Identifies a certificate in a keystore.";
     leaf certificate-name {
-      type string;
-      description
-        "An arbitrary name for the identity certificate chain requested.";
+      type certificate-name-ref;
+        description
+          "Identifies a certificate in a keystore.";
     }
   }
 
@@ -356,10 +304,10 @@ module ietf-tpm-remote-attestation {
       type string;
       config false;
       description
-        "Name of one or more unique TPMs on a device.  If this object exists, 
-        a selection should pull only the objects related to these TPM(s).  If 
-        it does not exist, all qualifying TPMs that are 'hardware-based'
-        equals true on the device are selected.";
+        "Name of one or more unique TPMs on a device.  If this object 
+        exists, a selection should pull only the objects related to 
+        these TPM(s).  If it does not exist, all qualifying TPMs that 
+        are 'hardware-based' equals true on the device are selected.";
     }
   }
  
@@ -395,6 +343,9 @@ module ietf-tpm-remote-attestation {
       description
         "This SHALL be the locality modifier required to release the
          information (TPM 1.2 type TPM_LOCALITY_SELECTION)";
+      reference
+        "TPM Main Part 2 TPM Structures v1.2 July 2007
+        Section 8.6";  
     }
     leaf digest-at-release {
       type binary;
@@ -402,6 +353,9 @@ module ietf-tpm-remote-attestation {
         "This SHALL be the digest of the PCR indices and PCR values
          to verify when revealing auth data (TPM 1.2 type
          TPM_COMPOSITE_HASH).";
+      reference
+        "TPM Main Part 2 TPM Structures v1.2 July 2007
+        Section 5.4.1.";      
     }
   }
 
@@ -413,6 +367,9 @@ module ietf-tpm-remote-attestation {
       description
         "This indicates the version of the structure
          (TPM 1.2 type TPM_STRUCT_VER). This MUST be 1.1.0.0.";
+      reference
+        "TPM Main Part 2 TPM Structures v1.2 July 2007
+        Section 5.1.";  
       leaf major {
         type uint8;
         description
@@ -442,7 +399,10 @@ module ietf-tpm-remote-attestation {
 
   grouping tpm12-quote-info-common {
     description
-      "These statements are used in bot quote variants of the TPM 1.2";
+      "These statements are within both quote variants of the TPM 1.2";
+    reference
+      "TPM Main Part 2 TPM Structures v1.2 July 2007, 
+      Section 11.3 & 11.4.";
     leaf fixed {
       type binary;
       description
@@ -462,7 +422,7 @@ module ietf-tpm-remote-attestation {
     leaf signature {
       type binary;
       description
-        "Signature over SHA-1 hash of tpm12-quote-info2'.";
+        "Signature over hash of tpm12-quote-info2'.";
     }
   }
 
@@ -500,6 +460,8 @@ module ietf-tpm-remote-attestation {
     list TPM_PCR_COMPOSITE {
       description
         "The TPM 1.2 TPM_PCRVALUEs for the pcr-indices.";
+      reference
+        "TPM Main Part 2 TPM Structures v1.2 July 2007, Section 8.2";
       uses tpm12-pcr-selection;
       leaf value-size {
         type uint32;
@@ -561,6 +523,8 @@ module ietf-tpm-remote-attestation {
     list TPM_PCR_COMPOSITE {
       description
         "The TPM 1.2 TPM_PCRVALUEs for the pcr-indices.";
+      reference
+        "TPM Main Part 2 TPM Structures v1.2 July 2007, Section 8.2";
       uses tpm12-pcr-selection;
       leaf value-size {
         type uint32;
@@ -590,8 +554,8 @@ module ietf-tpm-remote-attestation {
   grouping tpm12-attestation {
     description
       "Contains an instance of TPM1.2 style signed cryptoprocessor 
-      measurements.  It is supplemented by unsigned Attester information.";
-    uses certificate-name;
+      measurements.  It is supplemented by unsigned Attester 
+      information.";
     uses node-uptime;
     uses compute-node-identifier;
     uses tpm12-quote-info-common;
@@ -618,27 +582,35 @@ module ietf-tpm-remote-attestation {
   grouping tpm20-attestation {
     description
       "Contains an instance of TPM2 style signed cryptoprocessor 
-      measurements.  It is supplemented by unsigned Attester information.";
-    uses certificate-name;
-    uses node-uptime;
-    uses compute-node-identifier;
-    leaf quote {
+      measurements.  It is supplemented by unsigned Attester 
+      information.";
+    leaf TPMS_QUOTE_INFO {
+      mandatory true;
       type binary;
       description
-        "Quote data returned by TPM Quote, including PCR selection,
-         PCR digest and etc.";
+        "A hash of the latest PCR values (and the hash algorithm used) 
+        which have been returned from a Verifier for the selected PCRs 
+        and Hash Algorithms.";
+      reference
+        "https://www.trustedcomputinggroup.org/wp-content/uploads/
+        TPM-Rev-2.0-Part-2-Structures-01.38.pdf  Section 10.12.1";        
     }
     leaf quote-signature {
       type binary;
       description
-        "Quote signature returned by TPM Quote.";
-    }
-    list pcr-bank-values {
-      /* This often should not be necessary for TPM2, as the information
-         if validated will need to be coming from the 'quote' leaf       */
+        "Quote signature returned by TPM Quote.  The signature was
+        generated using the key associated with the 
+        certificate-name.";
+    } 
+    uses node-uptime;
+    uses compute-node-identifier;    
+    list unsigned-pcr-values {
       description
-        "PCR values in each PCR bank.";  
-      uses TPM2_Algo;
+        "PCR values in each PCR bank. This often should not be 
+         necessary for TPM2, as the raw information needing 
+         signature and hash validation will be coming from 
+         the 'quote' leaf";  
+      uses TPM20-hash-algo;
       list pcr-values {
         key pcr-index;
         description
@@ -654,11 +626,6 @@ module ietf-tpm-remote-attestation {
             "PCR value.";
         }
       }
-    }
-    container pcr-digest-algo-in-quote {
-      uses TPM2_Algo;
-      description
-        "The hash algorithm for PCR value digest in Quote output.";
     }
   }  
 
@@ -678,8 +645,8 @@ module ietf-tpm-remote-attestation {
 
   grouping boot-event-log {
     description
-      "Defines an event log corresponding to the event that extended the
-       PCR";
+      "Defines an event log corresponding to the event that extended 
+      the PCR";
     leaf event-number {
       type uint32;
       description
@@ -700,11 +667,11 @@ module ietf-tpm-remote-attestation {
         "Hash of event data";
       leaf hash-algo {
         type identityref {
-          base aa:asymmetric-algorithm-type;
+          base taa:hash;
         }
         description
-          "The hash scheme that is used to compress the event data in each of
-          the leaf-list digest items.";    
+          "The hash scheme that is used to compress the event data in 
+          each of the leaf-list digest items.";    
       }   
       leaf-list digest {
         type binary;
@@ -834,14 +801,12 @@ module ietf-tpm-remote-attestation {
   /**********************/
 
   rpc tpm12-challenge-response-attestation {
-    if-feature "TPM12";
+    if-feature "taa:TPM12";
     description
-      "This RPC accepts the input for TSS TPM 1.2 commands of the
-       managed device. ComponentIndex from the hardware manager YANG
-       module to refer to dedicated TPM in composite devices,
-       e.g. smart NICs, is still a TODO.";
+      "This RPC accepts the input for TSS TPM 1.2 commands made to the
+       attesting device.";
     input {
-      container tpm1-attestation-challenge {
+      container tpm12-attestation-challenge {
         description
           "This container includes every information element defined
            in the reference challenge-response interaction model for
@@ -849,33 +814,47 @@ module ietf-tpm-remote-attestation {
            TPM 1.2 structure definitions";
         uses tpm12-pcr-selection;
         uses nonce;
-        uses TPM12_Algo;
-        uses tpm12-attestation-key-identifier;
         leaf add-version {
           type boolean;
           description
             "Whether or not to include TPM_CAP_VERSION_INFO; if true,
              then TPM_Quote2 must be used to create the response.";
+          reference
+            "TPM Main Part 2 TPM Structures v1.2 July 2007, 
+            Section 21.6";
         }
-        uses tpm-name-selector;
-          /* if this scheme is desired, we should define XPATH to limit 
-           selection to just 'tpm-name' that are '../tpm-specification-version' 
-           equals 'TPM12' and where '../hardware-based' equals 'true' */
+        leaf-list certificate-name {
+          must "/tpm:rats-support-structures/tpm:tpms" +
+               "/tpm:tpm[tpm:tpm-firmware-version='tpm12']" +
+               "/tpm:certificates/" +
+               "/tpm:certificate[certificate-name-ref=current()]" {
+            error-message "Not an available TPM1.2 AIK certificate."; 
+          }  
+          type certificate-name-ref;
+          description
+            "When populated, the RPC will only get a Quote for the
+            TPMs associated with these certificate(s).";
+        }
       }
     }
     output {
       list tpm12-attestation-response {
+        unique "certificate-name"; 
         description
           "The binary output of TPM 1.2 TPM_Quote/TPM_Quote2, including
            the PCR selection and other associated attestation evidence
            metadata";
+        uses certificate-name-ref {
+          description
+            "Certificate associated with this tpm12-attestation.";
+        }
         uses tpm12-attestation;   
       }
     }
   }
 
   rpc tpm20-challenge-response-attestation {
-    if-feature "TPM20";
+    if-feature "taa:TPM20";
     description
       "This RPC accepts the input for TSS TPM 2.0 commands of the
        managed device. ComponentIndex from the hardware manager YANG
@@ -888,67 +867,34 @@ module ietf-tpm-remote-attestation {
            in the reference challenge-response interaction model for
            remote attestation. Corresponding values are based on
            TPM 2.0 structure definitions";
-        uses nonce;
-        list challenge-objects {
-          description
-            "Nodes to fetch attestation information, PCR selection
-             and AK identifier.";
-          uses tpm20-pcr-selection;
-          uses TPM2_Algo;
-          uses tpm20-attestation-key-identifier;
-          uses tpm-name-selector;
-          /* if this scheme is desired, we should define XPATH to limit 
-           selection to just 'tpm-name' that are '../tpm-specification-version' 
-           equals 'TPM2' and where '../hardware-based' equals 'true' */
+        uses nonce;       
+        uses tpm20-pcr-selection;
+        leaf-list certificate-name {
+          must "/tpm:rats-support-structures/tpm:tpms" +
+               "/tpm:tpm[tpm:tpm-firmware-version='tpm20']" +
+               "/tpm:certificates/" +
+               "/tpm:certificate[certificate-name-ref=current()]" {
+            error-message "Not an available TPM2.0 AIK certificate."; 
+          } 
+          type certificate-name-ref;
+            description
+              "When populated, the RPC will only get a Quote for the
+              TPMs associated with the certificates.";
         }
       }
     }
     output {
       list tpm20-attestation-response {
-        unique "certificate-name";   /* should have XPATH making this mandatory 
-                                when there is more than one list entry */
+        unique "certificate-name";   
         description
           "The binary output of TPM2b_Quote in one TPM chip of the
            node which identified by node-id. An TPMS_ATTEST structure
            including a length, encapsulated in a signature";
-        uses tpm20-attestation;
-      }
-    }
-  }
-
-  rpc basic-trust-establishment {   
-    description
-      "This RPC creates a tpm-resident, non-migratable key to be used
-       in TPM_Quote commands, an attestation certificate.";
-    input {
-      uses nonce;
-      uses TPM2_Algo;
-      leaf-list tpm-name {
-        when "not(../certificate-name)";  /* ensures both are not populated */
-        type string;
-        description
-          "Path to a unique TPM on a device.  If there are no elements in the
-          leaf-list, all TPMs which are 'hardware-based' should have keys 
-          established.";
-      }  
-      uses certificate-name {
-        description
-          "It is possible to request a new certificate using the old one as a 
-          reference.";
-      }
-    }
-    output {
-      list attestation-certificates {
-        description
-          "Attestation Certificate data from a TPM identified by the TPM
-           name";
-        leaf attestation-certificate {
-          type ct:end-entity-cert-cms;
+        uses certificate-name-ref {
           description
-            "The binary signed certificate chain data for this identity
-             certificate.";
+            "Certificate associated with this tpm20-attestation.";
         }
-        uses tpm20-attestation-key-identifier;
+        uses tpm20-attestation;
       }
     }
   }
@@ -961,7 +907,7 @@ module ietf-tpm-remote-attestation {
     input {
       list log-selector {
         description
-          "Selection of log entries to be reported.";
+          "Selection of log entries to be reported.";    
         uses tpm-name-selector;
         choice index-type {
           description
@@ -981,7 +927,8 @@ module ietf-tpm-remote-attestation {
           }
           case index {
             description
-              "Numeric index of the last log entry retrieved, or zero.";
+              "Numeric index of the last log entry retrieved, or 
+               zero.";
             leaf last-index-number {
               type uint64;
               description
@@ -995,8 +942,9 @@ module ietf-tpm-remote-attestation {
             leaf timestamp {
               type yang:date-and-time;
               description
-                "Timestamp from which to start the extraction.  The next
-                 log entry subsequent to this timestamp is to be sent.";
+                "Timestamp from which to start the extraction.  The 
+                 next log entry subsequent to this timestamp is to 
+                 be sent.";
             }
             description
               "Timestamp from which to start the extraction.";
@@ -1017,12 +965,12 @@ module ietf-tpm-remote-attestation {
         description
           "The requested data of the measurement event logs";
         list node-data {
-          unique "certificate-name";
+          unique "tpm-name";
           description
             "Event logs of a node in a distributed system
              identified by the node name";
+          uses tpm-name;
           uses node-uptime;
-          uses certificate-name;
           container log-result {
             description
               "The requested entries of the corresponding log.";
@@ -1042,146 +990,244 @@ module ietf-tpm-remote-attestation {
       "The datastore definition enabling verifiers or relying
        parties to discover the information necessary to use the
        remote attestation RPCs appropriately.";
-    leaf-list supported-algos {
-      config true;
-      type identityref {
-        base aa:asymmetric-algorithm-type;
-      }
+    container compute-nodes {
+      presence
+        "Indicates that more than one TPM exists on a device.";
       description
-        "Supported algorithms values for an Attester.";  
-    }
-    list compute-nodes {
-      config false;
-      key node-id;
-      uses compute-node-identifier;
-      description
-        "A list names of hardware components in this composite
-         device that RATS can be conducted with."; 
-      leaf node-name {
-        type string;
-        description
-          "Name of the compute node.";
-      }
-      leaf node-location {
-        type string;
-        description
-          "Location of the compute node, such as slot number.";
-      }
-    }
-    list tpms {
-      key tpm-name;
-      unique "tpm-path";
-      description
-        "A list of TPMs in this composite device that RATS
-         can be conducted with.";   
-      uses tpm-name;
-      leaf hardware-based {
+        "Holds the set device subsystems/components in this composite
+         device that support TPM operations.";
+      list compute-node {
+        key node-id;
         config false;
-        type boolean;
+        min-elements 2;
+        uses compute-node-identifier;
         description
-          "Answers the question: is this TPM is a hardware based TPM?";
-      }
-      leaf tpm-physical-index {
-        if-feature ietfhw:entity-mib;
-        config false;
-        type int32 {
-          range "1..2147483647";
-        }
-        description
-          "The entPhysicalIndex for the TPM.";
-        reference
-          "RFC 6933: Entity MIB (Version 4) - entPhysicalIndex";
-      } 
-      leaf tpm-path {
-        type string;
-        config false;
-        description
-          "Path to a unique TPM on a device.  This can change agross reboots.";
-      }
-
-      leaf compute-node {
-        when "../../compute-nodes";
-        config false;
-        mandatory true;
-        type compute-node-ref;
-        description
-          "When there is more that one TPM, this indicates for which 
-          compute node this TPM services.";
-      }
-      leaf tpm-manufacturer {
-        config false;
-        type string;
-        description
-          "TPM manufacturer name.";
-      }
-      leaf tpm-firmware-version {
-        config false;
-        type string;
-        description
-          "TPM firmware version.";
-      }
-      leaf tpm-specification-version {
-        type identityref {
-          base cryptoprocessor;
-        }
-        config false;
-        mandatory true;
-        description
-          "Identifies the cryptoprocessor API set supported";
-      }
-      leaf tpm-status {
-        type string;
-        config false;
-        description
-          "TPM chip self-test status, normal or abnormal.";
-      }
-      container certificates {
-        description
-          "The TPM's certificates, including EK certificates
-           and AK certificates.";
-        list certificate {
-          config true;
-          key "certificate-name";          
+          "A components in this composite device that RATS which 
+          supports TPM operations."; 
+        leaf node-name {
+          type string;
           description
-            "Three types of certificates can be accessed via
-             this statement, including Initial Attestation
-             Key Cert, Local Attestation Key Cert or
-             Endorsement Key Cert.";
-          uses certificate-name;      
-          leaf certificate-ref {
-            type leafref {
-              path "/ks:keystore/ks:asymmetric-keys/ks:asymmetric-key"
-                 + "/ks:certificates/ks:certificate/ks:name";
-            }
-            description
-              "A reference to a specific certificate of an
-               asymmetric key in the Keystore.";
-               /* Note: It is also possible to import a grouping which allows 
-               local definition via an imported keystore schema. */
+            "Name of the compute node.";
+        }
+        leaf node-location {
+          type string;
+          description
+            "Location of the compute node, such as slot number.";
+        }
+      }
+    }
+    container tpms {
+      description
+        "Holds the set of TPMs within an Attester.";
+      list tpm {
+        key tpm-name;
+        unique "tpm-path";
+          description
+           "A list of TPMs in this composite device that RATS
+           can be conducted with.";   
+        uses tpm-name;
+        leaf hardware-based {
+          type boolean;
+          config false;
+          description
+            "Answers the question: is this TPM is a hardware based TPM?";
+        }
+        leaf tpm-physical-index {
+          if-feature ietfhw:entity-mib;
+          type int32 {
+            range "1..2147483647";
           }
-          leaf certificate-type {
-            type enumeration {
-              enum endorsement-cert {
-                value 0;
-                description
-                  "Endorsement Key (EK) Certificate type.";
-              }
-              enum initial-attestation-cert {
-                value 1;
-                description
-                  "Initial Attestation key (IAK) Certificate type.";
-              }
-              enum local-attestation-cert {
-                value 2;
-                description
-                  "Local Attestation Key (LAK) Certificate type.";
-              }
+          config false;
+          description
+            "The entPhysicalIndex for the TPM.";
+          reference
+            "RFC 6933: Entity MIB (Version 4) - entPhysicalIndex";
+        } 
+        leaf tpm-path {
+          type string;
+          config false;
+          description
+            "Path to a unique TPM on a device.  This can change agross 
+            reboots.";
+        }
+        leaf compute-node {
+          when "../../../compute-nodes";
+          type compute-node-ref;
+          config false;
+          mandatory true;
+          description
+            "When there is more that one TPM, this indicates for which 
+            compute node this TPM services.";
+        }
+        leaf tpm-manufacturer {
+          type string;
+          config false;
+          description
+            "TPM manufacturer name.";
+        }
+        leaf tpm-firmware-version {
+          type identityref {
+            base cryptoprocessor;
+          }       
+          mandatory true;
+          description
+            "Identifies the cryptoprocessor API set supported.  This 
+            cannot be configured.  However it is not shown as such 
+            to eliminate YANG warnings related NMDA.";
+        }
+        uses TPM12-hash-algo {
+          if-feature "taa:TPM12";
+          refine TPM12-hash-algo {
+            must "../tpm-firmware-version = 'tpm12'";
+            description
+              "The hash algorithm used for PCRs on this TPM1.2 
+              compliant cryptoprocessor.";
+          }
+        }      
+        list tpm20-pcr-bank {
+          must "../tpm-firmware-version = 'tpm20'";
+          key "TPM20-hash-algo";
+          description
+            "Specifies the list of PCRs that should be extracted for
+            a specific Hash Algorithm.";
+          reference
+            "https://www.trustedcomputinggroup.org/wp-content/uploads/
+             TPM-Rev-2.0-Part-2-Structures-01.38.pdf  Section 10.9.7";
+          leaf TPM20-hash-algo {
+            must "/tpm:rats-support-structures"
+               + "/tpm:attester-supported-algos"
+               + "/tpm:tpm20-hash";
+            type identityref {
+              base taa:hash;
             }
             description
-              "Type of this certificate";
+              "The hash scheme actively being used to hash a 
+              one or more TPM2.0 PCRs.";
+          }    
+          leaf-list pcr-index {
+            type tpm:pcr;
+            description
+              "Defines what TPM2 Banks are available.  A bank is a set 
+              of PCRs which are extended using a particular hash 
+              algorithm.";
+          }
+        }             
+        leaf tpm-status {
+          type enumeration {
+            enum operational {
+              value 0;
+              description
+                "The TPM currently is currently running normally and
+                is ready to accept and process TPM quotes.";
+              reference
+                "TPM-Rev-2.0-Part-1-Architecture-01.07-2014-03-13.pdf
+                Section 12";
+            }
+            enum non-operational {
+              value 1;
+              description
+                "TPM is in a state such as startup or shutdown which 
+                precludes the processing of TPM quotes.";
+            }
+          }
+          config false;
+          description
+            "TPM chip self-test status, normal or abnormal.";
+        }
+        container certificates {
+          description
+            "The TPM's certificates, including EK certificates
+             and AK certificates.";
+          list certificate {
+            key "certificate-name";          
+            description
+              "Three types of certificates can be accessed via
+               this statement, including Initial Attestation
+               Key Cert, Local Attestation Key Cert or
+               Endorsement Key Cert.";
+            leaf certificate-name {
+              type string;
+              description
+                "An arbitrary name uniquely identifying a certificate
+                 associated within key within a TPM.";
+            }      
+            leaf certificate-keystore-ref {
+              type leafref {
+                path "/ks:keystore/ks:asymmetric-keys/ks:asymmetric-key"
+                   + "/ks:certificates/ks:certificate/ks:name";
+              }
+              description
+                "A reference to a specific certificate of an
+                 asymmetric key in the Keystore.";
+                 /* Note: It is also possible to import a grouping which 
+                    allows local definition via an imported keystore 
+                    schema. */
+            }
+            leaf certificate-type {
+              type enumeration {
+                enum endorsement-cert {
+                  value 0;
+                  description
+                    "Endorsement Key (EK) Certificate type.";
+                }
+                enum initial-attestation-cert {
+                  value 1;
+                  description
+                    "Initial Attestation key (IAK) Certificate type.";
+                }
+                enum local-attestation-cert {
+                  value 2;
+                  description
+                    "Local Attestation Key (LAK) Certificate type.";
+                }
+              }
+              description
+                "Type of this certificate";
+            }
           }
         }
       }
+    }
+    container attester-supported-algos {
+      description
+        "Identifies which TPM algorithms are available for use on an
+        attesting platform.";
+      leaf-list tpm12-asymmetric-signing {
+        if-feature "taa:TPM12";
+        when "../../tpm:tpms/tpm:tpm[tpm:tpm-firmware-version='tpm12']";
+        type identityref {
+          base taa:asymmetric;
+        }
+        description
+          "Platform Supported TPM12 asymmetric algorithms.";  
+      }
+      leaf-list tpm12-hash {
+        if-feature "taa:TPM12";
+        when "../../tpm:tpms/tpm:tpm[tpm:tpm-firmware-version='tpm12']";
+        type identityref {
+          base taa:hash;
+        }
+        description
+          "Platform supported TPM12 hash algorithms.";  
+      }
+      leaf-list tpm20-asymmetric-signing {
+        if-feature "taa:TPM20";
+        when "../../tpm:tpms/tpm:tpm[tpm:tpm-firmware-version='tpm20']";
+        type identityref {
+          base taa:asymmetric;
+        }
+        description
+          "Platform Supported TPM20 asymmetric algorithms.";    
+      }
+      leaf-list tpm20-hash {
+        if-feature "taa:TPM20";
+        when "../../tpm:tpms/tpm:tpm[tpm:tpm-firmware-version='tpm20']";
+        type identityref {
+          base taa:hash;
+        }
+        description
+          "Platform supported TPM12 hash algorithms.";  
+      }          
     }
   }
 }


### PR DESCRIPTION
Rework of many elements of the YANG file to vastly reduce the number of possible error conditions and viable mis-configurations.
• Enforcement of specific TPM hash and signing algos
• Suggesting default hash and signing algorithms (e.g., SHA-1 is the hash algo for TPM1.2.)
• Having a list of supported hash and signing algorithms for a platform (enforcing that the RPCs must use only these).
• Making references to externally stored certificates
• Got rid of the basic trust establishment RPC. This can be accomplished with other RPCs not in this model.
• Added references to various TPM specifications
• Error conditions identified in RPC
• Got rid of UUID as nobody seems to want it
• Extra containers for tpms and compute-nodes to make the tree more readable (following standard YANG practice)

All of these changes need additional viewership and scrubbing. Especially the XPATH needs checking as I was guessing in many cases.