### PR TITLE
Update ietf-tpm-remote-attestation.tree

### DIFF
--- a/ietf-tpm-remote-attestation.tree
+++ b/ietf-tpm-remote-attestation.tree
@@ -16,6 +16,7 @@ module: ietf-tpm-remote-attestation
      |     +--ro tpm-manufacturer?       string
      |     +--rw tpm-firmware-version    identityref
      |     +--rw TPM12-hash-algo?        identityref
+     |     +--rw TPM12-pcrs*             pcr
      |     +--rw tpm20-pcr-bank* [TPM20-hash-algo]
      |     |  +--rw TPM20-hash-algo    identityref
      |     |  +--rw pcr-index*         tpm:pcr


### PR DESCRIPTION
Tweaks, such as adding a leaf of what TPM1.2 PCRs may be remotely quoted.  This allows RPCs to verify that the PCR is something which can be extracted.